### PR TITLE
Replace spaces by html non-breaking spaces in the list of authors

### DIFF
--- a/website/frontend/__init__.py
+++ b/website/frontend/__init__.py
@@ -35,6 +35,9 @@ def create_app():
     from website.expand import expand
     app.jinja_env.filters['expand'] = expand
 
+    from website.nbsp_list import nbsp_list
+    app.jinja_env.filters['nbsp_list'] = nbsp_list
+
     # Blueprints
     from views import frontend_bp
     from views.changelog import changelog_bp

--- a/website/frontend/templates/plugins.html
+++ b/website/frontend/templates/plugins.html
@@ -29,7 +29,7 @@
               <td>{{ plugin["name"] }}</td>
               <td>{{ plugin["version"] }}</td>
               <td>{{ plugin["description"] | safe }}</td>
-              <td>{{ plugin["author"] }}</td>
+              <td>{{ plugin["author"] | nbsp_list | safe }}</td>
               <td class="text-center">
                 <a class="btn btn-primary btn-sm" href="/api/v1/download?id={{ id }}">{{ _("Download") }}</a>
               </td>

--- a/website/nbsp_list.py
+++ b/website/nbsp_list.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import re
+import jinja2
+
+
+def nbsp_list(string, separator=','):
+    """
+    Replace spaces inside of elements of a list separated by `separator` by
+    non-breaking spaces.
+    Multiple spaces are considered as one.
+    Proper html escaping is done, so one needs to use `safe` filter in templates
+    to prevent double escaping.
+    Example:
+        <i>te  st</i>,  some thing
+    --> &lt;i&gt;te&nbsp;st&lt;/i&gt;, some&nbsp;thing
+    """
+    newelems = []
+    for elem in re.split(re.escape(separator) + ' *', string):
+        newparts = []
+        for part in re.split(r' +', elem):
+            newparts.append(jinja2.escape(part))
+        newelems.append('&nbsp;'.join(newparts))
+    sep = separator + ' '
+    return sep.join(newelems)

--- a/website/nbsp_list_test.py
+++ b/website/nbsp_list_test.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import unittest
+from website.nbsp_list import nbsp_list
+
+
+class MyTestCase(unittest.TestCase):
+
+    def test_nbsp_list_1(self):
+        "Empty string"
+        s = u''
+        expected = u''
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_2(self):
+        "Simple string"
+        s = u'test'
+        expected = u'test'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_3(self):
+        "Simple string with html tag"
+        s = u'te<i>st'
+        expected = u'te&lt;i&gt;st'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_4(self):
+        "Simple string with space"
+        s = u'te st'
+        expected = u'te&nbsp;st'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_5(self):
+        "List, no space"
+        s = u'test1,test2'
+        expected = u'test1, test2'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_6(self):
+        "List, multiple spaces after comma"
+        s = u'test1,   test2'
+        expected = u'test1, test2'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_7(self):
+        "List, multiple spaces in elements"
+        s = u'te  st1, te  st2'
+        expected = u'te&nbsp;st1, te&nbsp;st2'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_8(self):
+        "List, multiple spaces in elements and escaping"
+        s = u'te  st1, te  <s>t2'
+        expected = u'te&nbsp;st1, te&nbsp;&lt;s&gt;t2'
+        self.assertEqual(expected, nbsp_list(s))
+
+    def test_nbsp_list_9(self):
+        "List, multiple spaces in elements and escaping, different separator"
+        s = u'te  st1* te  <s>t2'
+        expected = u'te&nbsp;st1* te&nbsp;&lt;s&gt;t2'
+        self.assertEqual(expected, nbsp_list(s, '*'))
+
+    def test_nbsp_list_10(self):
+        "Complex list and escaping"
+        s = u'te  st1; te  <s>t2;&nbsp;'
+        expected = u'te&nbsp;st1; te&nbsp;&lt;s&gt;t2; &amp;nbsp; '
+        self.assertEqual(expected, nbsp_list(s, ';'))


### PR DESCRIPTION
This was proposed by Sophist, see discussion at https://github.com/musicbrainz/picard-plugins/pull/7#discussion-diff-23888033

The change was reverted because it was doing formatting on the JSON side.

This patch implements a website-side solution doing the same thing.
The nbsp_list function takes care of escaping (hence the `safe` filter in the template).