### PR TITLE
Picard 1.3 tag mapping

### DIFF
--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -261,7 +261,9 @@
           <td>
           </td>
           <td>
-            <code>WM/OriginalReleaseYear</code>
+            <code>WM/OriginalReleaseTime</code> <i>(Picard&gt;=1.4)</i>
+            <br />
+            <code>WM/OriginalReleaseYear</code> <i>(Picard&lt;=1.3)</i>
           </td>
         </tr>
         <tr>
@@ -282,6 +284,7 @@
           <td>
           </td>
           <td>
+            <code>WM/OriginalReleaseYear</code>
           </td>
         </tr>
         <tr>
@@ -746,6 +749,7 @@
             <code>disk</code>
           </td>
           <td>
+            <code>WM/PartOfSet</code> <i>(Picard&gt;=1.4)</i>
           </td>
         </tr>
         <tr>
@@ -1213,7 +1217,7 @@
           <td>
           </td>
           <td>
-            <code>WM/EncoderSettings</code>
+            <code>WM/EncodingSettings</code> <i>(Picard&gt;=1.4)</i>
           </td>
         </tr>
         <tr>
@@ -1602,6 +1606,7 @@
           <td>
           </td>
           <td>
+            <code>WM/AuthorURL</code> <i>(Picard&gt;=1.4)</i>
           </td>
         </tr>
       </table>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -261,9 +261,9 @@
           <td>
           </td>
           <td>
-            <code>WM/OriginalReleaseTime</code> <i>(Picard&gt;=1.4)</i>
+            <code>WM/OriginalReleaseTime</code> <i>(Picard&gt;=1.3.1)</i>
             <br />
-            <code>WM/OriginalReleaseYear</code> <i>(Picard&lt;=1.3)</i>
+            <code>WM/OriginalReleaseYear</code> <i>(Picard&lt;=1.3.0)</i>
           </td>
         </tr>
         <tr>
@@ -284,7 +284,7 @@
           <td>
           </td>
           <td>
-            <code>WM/OriginalReleaseYear</code>
+            <code>WM/OriginalReleaseYear</code> <i>(Picard&gt;=1.3.1)</i>
           </td>
         </tr>
         <tr>
@@ -749,7 +749,7 @@
             <code>disk</code>
           </td>
           <td>
-            <code>WM/PartOfSet</code> <i>(Picard&gt;=1.4)</i>
+            <code>WM/PartOfSet</code> <i>(Picard&gt;=1.3.1)</i>
           </td>
         </tr>
         <tr>
@@ -1217,7 +1217,7 @@
           <td>
           </td>
           <td>
-            <code>WM/EncodingSettings</code> <i>(Picard&gt;=1.4)</i>
+            <code>WM/EncodingSettings</code> <i>(Picard&gt;=1.3.1)</i>
           </td>
         </tr>
         <tr>
@@ -1606,7 +1606,7 @@
           <td>
           </td>
           <td>
-            <code>WM/AuthorURL</code> <i>(Picard&gt;=1.4)</i>
+            <code>WM/AuthorURL</code> <i>(Picard&gt;=1.3.1)</i>
           </td>
         </tr>
       </table>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -42,6 +42,28 @@
           </td>
         </tr>
         <tr>
+          <th>Album Sort Order<sup id="cite_ref-notinstockpicard_3-7" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          </th>
+          <td>
+            <code>albumsort</code>
+          </td>
+          <td>
+            <code>TSOA</code>
+          </td>
+          <td>
+            <code>ALBUMSORT</code>
+          </td>
+          <td>
+            <code>ALBUMSORT</code>
+          </td>
+          <td>
+            <code>soal</code>
+          </td>
+          <td>
+            <code>WM/AlbumSortOrder</code>
+          </td>
+        </tr>
+        <tr>
           <th> <a href="http://musicbrainz.org/doc/Track_Title" title="Track Title">Track Title</a>
           </th>
           <td>
@@ -61,6 +83,48 @@
           </td>
           <td>
             <code>Title</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Track Title Sort Order<sup id="cite_ref-notinstockpicard_3-8" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          </th>
+          <td>
+            <code>titlesort</code>
+          </td>
+          <td>
+            <code>TSOT</code>
+          </td>
+          <td>
+            <code>TITLESORT</code>
+          </td>
+          <td>
+            <code>TITLESORT</code>
+          </td>
+          <td>
+            <code>sonm</code>
+          </td>
+          <td>
+            <code>WM/TitleSortOrder</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Work Title (Picard&gt;=1.3)
+          </th>
+          <td>
+            <code>work</code>
+          </td>
+          <td>
+            <code>TOAL</code>
+          </td>
+          <td>
+            <code>WORK</code>
+          </td>
+          <td>
+            <code>WORK</code>
+          </td>
+          <td>
+          </td>
+          <td>
           </td>
         </tr>
         <tr>
@@ -86,6 +150,28 @@
           </td>
         </tr>
         <tr>
+          <th>Artist Sort Order
+          </th>
+          <td>
+            <code>artistsort</code>
+          </td>
+          <td>
+            <code>TSOP</code>
+          </td>
+          <td>
+            <code>ARTISTSORT</code>
+          </td>
+          <td>
+            <code>ARTISTSORT</code>
+          </td>
+          <td>
+            <code>soar</code>
+          </td>
+          <td>
+            <code>WM/ArtistSortOrder</code>
+          </td>
+        </tr>
+        <tr>
           <th> <a href="http://musicbrainz.org/doc/Release_Artist" title="Release Artist">Album Artist</a>
           </th>
           <td>
@@ -105,6 +191,30 @@
           </td>
           <td>
             <code>WM/AlbumArtist</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Album Artist Sort Order
+          </th>
+          <td>
+            <code>albumartistsort</code>
+          </td>
+          <td>
+            <code>TSO2</code> <i>(Picard&gt;=1.2)</i>
+            <br />
+            <code>TXXX:ALBUMARTISTSORT</code> <i>(Picard&lt;=1.1)</i>
+          </td>
+          <td>
+            <code>ALBUMARTISTSORT</code>
+          </td>
+          <td>
+            <code>ALBUMARTISTSORT</code>
+          </td>
+          <td>
+            <code>soaa</code>
+          </td>
+          <td>
+            <code>WM/AlbumArtistSortOrder</code>
           </td>
         </tr>
         <tr>
@@ -155,6 +265,26 @@
           </td>
         </tr>
         <tr>
+          <th>Original Release Year <sup id="cite_ref-lastfmplugin_2-2" class="reference"><a href="#cite_note-lastfmplugin-2">[3]</a></sup>
+          </th>
+          <td>
+            <code>originalyear</code>
+          </td>
+          <td>
+            <code>TXXX:originalyear</code>
+          </td>
+          <td>
+            <code>ORIGINALYEAR</code>
+          </td>
+          <td>
+            <code>ORIGINALYEAR</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
           <th> <a href="http://musicbrainz.org/relationship/d59d99ea-23d4-4a80-b066-edca32ee158f" class="extiw"
             title="rt:d59d99ea-23d4-4a80-b066-edca32ee158f">Composer</a>
           </th>
@@ -175,6 +305,30 @@
           </td>
           <td>
             <code>WM/Composer</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Composer Sort Order
+          </th>
+          <td>
+            <code>composersort</code>
+          </td>
+          <td>
+            <code>TSOC</code> <i>(Picard&gt;=1.3)</i>
+            <br />
+            <code>TXXX:COMPOSERSORT</code> <i>(Picard&lt;=1.2)</i>
+          </td>
+          <td>
+            <code>COMPOSERSORT</code>
+          </td>
+          <td>
+            <code>COMPOSERSORT</code>
+          </td>
+          <td>
+            <code>soco</code>
+          </td>
+          <td>
+            <code>WM/ComposerSortOrder</code> <i>(Picard&gt;=1.3)</i>
           </td>
         </tr>
         <tr>
@@ -418,6 +572,28 @@
           </td>
           <td>
             <code>WM/Mixer</code>
+          </td>
+        </tr>
+        <tr>
+          <th> <a href="http://musicbrainz.org/doc/Label_Name" title="Label Name">Record Label</a>
+          </th>
+          <td>
+            <code>label</code>
+          </td>
+          <td>
+            <code>TPUB</code>
+          </td>
+          <td>
+            <code>LABEL</code>
+          </td>
+          <td>
+            <code>Label</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:LABEL</code>
+          </td>
+          <td>
+            <code>WM/Publisher</code>
           </td>
         </tr>
         <tr>
@@ -703,50 +879,6 @@
           </td>
         </tr>
         <tr>
-          <th> <a href="http://musicbrainz.org/doc/ISRC" title="ISRC">ISRC</a>
-          </th>
-          <td>
-            <code>isrc</code>
-          </td>
-          <td>
-            <code>TSRC</code>
-          </td>
-          <td>
-            <code>ISRC</code>
-          </td>
-          <td>
-            <code>ISRC</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:ISRC</code>
-          </td>
-          <td>
-            <code>WM/ISRC</code>
-          </td>
-        </tr>
-        <tr>
-          <th>Copyright<sup id="cite_ref-notinstockpicard_3-3" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
-          </th>
-          <td>
-            <code>copyright</code>
-          </td>
-          <td>
-            <code>TCOP</code>
-          </td>
-          <td>
-            <code>COPYRIGHT</code>
-          </td>
-          <td>
-            <code>Copyright</code>
-          </td>
-          <td>
-            <code>cprt</code>
-          </td>
-          <td>
-            <code>Copyright</code>
-          </td>
-        </tr>
-        <tr>
           <th>Lyrics<sup id="cite_ref-notinstockpicard_3-4" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
           </th>
           <td>
@@ -791,28 +923,6 @@
           </td>
         </tr>
         <tr>
-          <th> <a href="http://musicbrainz.org/doc/Label_Name" title="Label Name">Record Label</a>
-          </th>
-          <td>
-            <code>label</code>
-          </td>
-          <td>
-            <code>TPUB</code>
-          </td>
-          <td>
-            <code>LABEL</code>
-          </td>
-          <td>
-            <code>Label</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:LABEL</code>
-          </td>
-          <td>
-            <code>WM/Publisher</code>
-          </td>
-        </tr>
-        <tr>
           <th> <a href="http://musicbrainz.org/doc/Release_Catalog_Number" title="Release Catalog Number">Catalog Number</a>
           </th>
           <td>
@@ -835,25 +945,232 @@
           </td>
         </tr>
         <tr>
-          <th> <a href="http://musicbrainz.org/doc/Barcode" title="Barcode">Barcode</a>
+          <th>Show Name<sup id="cite_ref-notinstockpicard_3-13" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
           </th>
           <td>
-            <code>barcode</code>
+            <code>show</code>
           </td>
           <td>
-            <code>TXXX:BARCODE</code>
           </td>
           <td>
-            <code>BARCODE</code>
           </td>
           <td>
-            <code>Barcode</code>
           </td>
           <td>
-            <code>----:com.apple.iTunes:BARCODE</code>
+            <code>tvsh</code>
           </td>
           <td>
-            <code>WM/Barcode</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Show Name Sort Order<sup id="cite_ref-notinstockpicard_3-9" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          </th>
+          <td>
+            <code>showsort</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>sosn</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <th>Podcast<sup id="cite_ref-notinstockpicard_3-11" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          </th>
+          <td>
+            <code>podcast</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>pcst</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <th>Podcast URL<sup id="cite_ref-notinstockpicard_3-12" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          </th>
+          <td>
+            <code>podcasturl</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>purl</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <th> <a href="http://musicbrainz.org/doc/Release_Status" title="Release Status">Release Status</a>
+          </th>
+          <td>
+            <code>releasestatus</code>
+          </td>
+          <td>
+            <code>TXXX:MusicBrainz Album Status</code>
+          </td>
+          <td>
+            <code>RELEASESTATUS</code>
+          </td>
+          <td>
+            <code>MUSICBRAINZ_ALBUMSTATUS</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:MusicBrainz Album Status</code>
+          </td>
+          <td>
+            <code>MusicBrainz/Album Status</code>
+          </td>
+        </tr>
+        <tr>
+          <th> <a href="http://musicbrainz.org/doc/Release_Type" title="Release Type">Release Type</a>
+          </th>
+          <td>
+            <code>releasetype</code>
+          </td>
+          <td>
+            <code>TXXX:MusicBrainz Album Type</code>
+          </td>
+          <td>
+            <code>RELEASETYPE</code>
+          </td>
+          <td>
+            <code>MUSICBRAINZ_ALBUMTYPE</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:MusicBrainz Album Type</code>
+          </td>
+          <td>
+            <code>MusicBrainz/Album Type</code>
+          </td>
+        </tr>
+        <tr>
+          <th> <a href="http://musicbrainz.org/doc/Release_Country" title="Release Country">Release Country</a>
+          </th>
+          <td>
+            <code>releasecountry</code>
+          </td>
+          <td>
+            <code>TXXX:MusicBrainz Album Release Country</code>
+          </td>
+          <td>
+            <code>RELEASECOUNTRY</code>
+          </td>
+          <td>
+            <code>RELEASECOUNTRY</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:MusicBrainz Album Release Country</code>
+          </td>
+          <td>
+            <code>MusicBrainz/Album Release Country</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Script
+          </th>
+          <td>
+            <code>script</code>
+          </td>
+          <td>
+            <code>TXXX:SCRIPT</code>
+          </td>
+          <td>
+            <code>SCRIPT</code>
+          </td>
+          <td>
+            <code>Script</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:SCRIPT</code>
+          </td>
+          <td>
+            <code>WM/Script</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Language
+          </th>
+          <td>
+            <code>language</code>
+          </td>
+          <td>
+            <code>TLAN</code>
+          </td>
+          <td>
+            <code>LANGUAGE</code>
+          </td>
+          <td>
+            <code>Language</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:LANGUAGE</code>
+          </td>
+          <td>
+            <code>WM/Language</code>
+          </td>
+        </tr>
+        <tr>
+          <th>Copyright<sup id="cite_ref-notinstockpicard_3-3" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          </th>
+          <td>
+            <code>copyright</code>
+          </td>
+          <td>
+            <code>TCOP</code>
+          </td>
+          <td>
+            <code>COPYRIGHT</code>
+          </td>
+          <td>
+            <code>Copyright</code>
+          </td>
+          <td>
+            <code>cprt</code>
+          </td>
+          <td>
+            <code>Copyright</code>
+          </td>
+        </tr>
+        <tr>
+          <th>License <sup id="cite_ref-5" class="reference"><a href="#cite_note-5">[6]</a></sup>  <sup id="cite_ref-6"
+            class="reference"><a href="#cite_note-6">[7]</a></sup>
+          </th>
+          <td>
+            <code>license</code>
+          </td>
+          <td>
+            <code>WCOP</code> <i>(single URL)</i>
+            <br />
+            <code>TXXX:LICENSE</code>(multiple or non-URL)
+          </td>
+          <td>
+            <code>LICENSE</code>
+          </td>
+          <td>
+            <code>LICENSE</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:LICENSE</code>
+          </td>
+          <td>
+            <code>LICENSE</code>
           </td>
         </tr>
         <tr>
@@ -900,133 +1217,84 @@
           </td>
         </tr>
         <tr>
-          <th>Album Sort Order<sup id="cite_ref-notinstockpicard_3-7" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          <th>Gapless Playback<sup id="cite_ref-notinstockpicard_3-10" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
           </th>
           <td>
-            <code>albumsort</code>
+            <code>gapless</code>
           </td>
           <td>
-            <code>TSOA</code>
           </td>
           <td>
-            <code>ALBUMSORT</code>
           </td>
           <td>
-            <code>ALBUMSORT</code>
           </td>
           <td>
-            <code>soal</code>
+            <code>pgap</code>
           </td>
           <td>
-            <code>WM/AlbumSortOrder</code>
           </td>
         </tr>
         <tr>
-          <th>Album Artist Sort Order
+          <th> <a href="http://musicbrainz.org/doc/Barcode" title="Barcode">Barcode</a>
           </th>
           <td>
-            <code>albumartistsort</code>
+            <code>barcode</code>
           </td>
           <td>
-            <code>TSO2</code> <i>(Picard&gt;=1.2)</i>
-            <br />
-            <code>TXXX:ALBUMARTISTSORT</code> <i>(Picard&lt;=1.1)</i>
+            <code>TXXX:BARCODE</code>
           </td>
           <td>
-            <code>ALBUMARTISTSORT</code>
+            <code>BARCODE</code>
           </td>
           <td>
-            <code>ALBUMARTISTSORT</code>
+            <code>Barcode</code>
           </td>
           <td>
-            <code>soaa</code>
+            <code>----:com.apple.iTunes:BARCODE</code>
           </td>
           <td>
-            <code>WM/AlbumArtistSortOrder</code>
+            <code>WM/Barcode</code>
           </td>
         </tr>
         <tr>
-          <th>Artist Sort Order
+          <th> <a href="http://musicbrainz.org/doc/ISRC" title="ISRC">ISRC</a>
           </th>
           <td>
-            <code>artistsort</code>
+            <code>isrc</code>
           </td>
           <td>
-            <code>TSOP</code>
+            <code>TSRC</code>
           </td>
           <td>
-            <code>ARTISTSORT</code>
+            <code>ISRC</code>
           </td>
           <td>
-            <code>ARTISTSORT</code>
+            <code>ISRC</code>
           </td>
           <td>
-            <code>soar</code>
+            <code>----:com.apple.iTunes:ISRC</code>
           </td>
           <td>
-            <code>WM/ArtistSortOrder</code>
+            <code>WM/ISRC</code>
           </td>
         </tr>
         <tr>
-          <th>Title Sort Order<sup id="cite_ref-notinstockpicard_3-8" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
+          <th> <a href="http://musicbrainz.org/doc/ASIN" title="ASIN">ASIN</a>
           </th>
           <td>
-            <code>titlesort</code>
+            <code>asin</code>
           </td>
           <td>
-            <code>TSOT</code>
+            <code>TXXX:ASIN</code>
           </td>
           <td>
-            <code>TITLESORT</code>
+            <code>ASIN</code>
           </td>
           <td>
-            <code>TITLESORT</code>
+            <code>ASIN</code>
           </td>
           <td>
-            <code>sonm</code>
-          </td>
-          <td>
-            <code>WM/TitleSortOrder</code>
-          </td>
-        </tr>
-        <tr>
-          <th>Composer Sort Order
-          </th>
-          <td>
-            <code>composersort</code>
-          </td>
-          <td>
-            <code>TSOC</code> <i>(Picard&gt;=1.3)</i>
-            <br />
-            <code>TXXX:COMPOSERSORT</code> <i>(Picard&lt;=1.2)</i>
-          </td>
-          <td>
-            <code>COMPOSERSORT</code>
-          </td>
-          <td>
-            <code>COMPOSERSORT</code>
-          </td>
-          <td>
-            <code>soco</code>
-          </td>
-          <td>
-            <code>WM/ComposerSortOrder</code> <i>(Picard&gt;=1.3)</i>
-          </td>
-        </tr>
-        <tr>
-          <th>Show Name Sort Order<sup id="cite_ref-notinstockpicard_3-9" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
-          </th>
-          <td>
-            <code>showsort</code>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-            <code>sosn</code>
+            <code>----:com.apple.iTunes:ASIN</code>
           </td>
           <td>
           </td>
@@ -1143,295 +1411,6 @@
           </td>
         </tr>
         <tr>
-          <th> <a href="http://musicbrainz.org/doc/TRM" title="TRM">MusicBrainz TRM Id</a>
-          </th>
-          <td>
-            <code>musicbrainz_trmid</code>
-          </td>
-          <td>
-            <code>TXXX:MusicBrainz TRM Id</code>
-          </td>
-          <td>
-            <code>MUSICBRAINZ_TRMID</code>
-          </td>
-          <td>
-            <code>MUSICBRAINZ_TRMID</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:MusicBrainz TRM Id</code>
-          </td>
-          <td>
-            <code>MusicBrainz/TRM Id</code>
-          </td>
-        </tr>
-        <tr>
-          <th> <a href="http://musicbrainz.org/doc/Disc_ID" title="Disc ID">MusicBrainz Disc Id</a>
-          </th>
-          <td>
-            <code>musicbrainz_discid</code>
-          </td>
-          <td>
-            <code>TXXX:MusicBrainz Disc Id</code>
-          </td>
-          <td>
-            <code>MUSICBRAINZ_DISCID</code>
-          </td>
-          <td>
-            <code>MUSICBRAINZ_DISCID</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:MusicBrainz Disc Id</code>
-          </td>
-          <td>
-            <code>MusicBrainz/Disc Id</code>
-          </td>
-        </tr>
-        <tr>
-          <th> <a href="http://musicbrainz.org/doc/PUID" title="PUID">MusicIP PUID</a>
-          </th>
-          <td>
-            <code>musicip_puid</code>
-          </td>
-          <td>
-            <code>TXXX:MusicIP PUID</code>
-          </td>
-          <td>
-            <code>MUSICIP_PUID</code>
-          </td>
-          <td>
-            <code>MUSICIP_PUID</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:MusicIP PUID</code>
-          </td>
-          <td>
-            <code>MusicIP/PUID</code>
-          </td>
-        </tr>
-        <tr>
-          <th>MusicIP Fingerprint
-          </th>
-          <td>
-            <code>musicip_fingerprint</code>
-          </td>
-          <td>
-            <code>TXXX:MusicMagic Fingerprint</code>
-          </td>
-          <td>
-            <code>FINGERPRINT=MusicMagic Fingerprint</code> <i>{fingerprint}</i>
-          </td>
-          <td>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:fingerprint</code>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th> <a href="http://musicbrainz.org/doc/Release_Status" title="Release Status">Release Status</a>
-          </th>
-          <td>
-            <code>releasestatus</code>
-          </td>
-          <td>
-            <code>TXXX:MusicBrainz Album Status</code>
-          </td>
-          <td>
-            <code>RELEASESTATUS</code>
-          </td>
-          <td>
-            <code>MUSICBRAINZ_ALBUMSTATUS</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:MusicBrainz Album Status</code>
-          </td>
-          <td>
-            <code>MusicBrainz/Album Status</code>
-          </td>
-        </tr>
-        <tr>
-          <th> <a href="http://musicbrainz.org/doc/Release_Type" title="Release Type">Release Type</a>
-          </th>
-          <td>
-            <code>releasetype</code>
-          </td>
-          <td>
-            <code>TXXX:MusicBrainz Album Type</code>
-          </td>
-          <td>
-            <code>RELEASETYPE</code>
-          </td>
-          <td>
-            <code>MUSICBRAINZ_ALBUMTYPE</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:MusicBrainz Album Type</code>
-          </td>
-          <td>
-            <code>MusicBrainz/Album Type</code>
-          </td>
-        </tr>
-        <tr>
-          <th> <a href="http://musicbrainz.org/doc/Release_Country" title="Release Country">Release Country</a>
-          </th>
-          <td>
-            <code>releasecountry</code>
-          </td>
-          <td>
-            <code>TXXX:MusicBrainz Album Release Country</code>
-          </td>
-          <td>
-            <code>RELEASECOUNTRY</code>
-          </td>
-          <td>
-            <code>RELEASECOUNTRY</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:MusicBrainz Album Release Country</code>
-          </td>
-          <td>
-            <code>MusicBrainz/Album Release Country</code>
-          </td>
-        </tr>
-        <tr>
-          <th> <a href="http://musicbrainz.org/doc/ASIN" title="ASIN">ASIN</a>
-          </th>
-          <td>
-            <code>asin</code>
-          </td>
-          <td>
-            <code>TXXX:ASIN</code>
-          </td>
-          <td>
-            <code>ASIN</code>
-          </td>
-          <td>
-            <code>ASIN</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:ASIN</code>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th>Gapless Playback<sup id="cite_ref-notinstockpicard_3-10" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
-          </th>
-          <td>
-            <code>gapless</code>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-            <code>pgap</code>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th>Podcast<sup id="cite_ref-notinstockpicard_3-11" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
-          </th>
-          <td>
-            <code>podcast</code>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-            <code>pcst</code>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th>Podcast URL<sup id="cite_ref-notinstockpicard_3-12" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
-          </th>
-          <td>
-            <code>podcasturl</code>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-            <code>purl</code>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th>Show Name<sup id="cite_ref-notinstockpicard_3-13" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup>
-          </th>
-          <td>
-            <code>show</code>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-            <code>tvsh</code>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th>Script
-          </th>
-          <td>
-            <code>script</code>
-          </td>
-          <td>
-            <code>TXXX:SCRIPT</code>
-          </td>
-          <td>
-            <code>SCRIPT</code>
-          </td>
-          <td>
-            <code>Script</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:SCRIPT</code>
-          </td>
-          <td>
-            <code>WM/Script</code>
-          </td>
-        </tr>
-        <tr>
-          <th>Language
-          </th>
-          <td>
-            <code>language</code>
-          </td>
-          <td>
-            <code>TLAN</code>
-          </td>
-          <td>
-            <code>LANGUAGE</code>
-          </td>
-          <td>
-            <code>Language</code>
-          </td>
-          <td>
-            <code>----:com.apple.iTunes:LANGUAGE</code>
-          </td>
-          <td>
-            <code>WM/Language</code>
-          </td>
-        </tr>
-        <tr>
           <th>MusicBrainz Release Group Id
           </th>
           <td>
@@ -1476,48 +1455,47 @@
           </td>
         </tr>
         <tr>
-          <th>License <sup id="cite_ref-5" class="reference"><a href="#cite_note-5">[6]</a></sup>  <sup id="cite_ref-6"
-            class="reference"><a href="#cite_note-6">[7]</a></sup>
+          <th> <a href="http://musicbrainz.org/doc/TRM" title="TRM">MusicBrainz TRM Id</a>
           </th>
           <td>
-            <code>license</code>
+            <code>musicbrainz_trmid</code>
           </td>
           <td>
-            <code>WCOP</code> <i>(single URL)</i>
-            <br />
-            <code>TXXX:LICENSE</code>(multiple or non-URL)
+            <code>TXXX:MusicBrainz TRM Id</code>
           </td>
           <td>
-            <code>LICENSE</code>
+            <code>MUSICBRAINZ_TRMID</code>
           </td>
           <td>
-            <code>LICENSE</code>
+            <code>MUSICBRAINZ_TRMID</code>
           </td>
           <td>
-            <code>----:com.apple.iTunes:LICENSE</code>
+            <code>----:com.apple.iTunes:MusicBrainz TRM Id</code>
           </td>
           <td>
-            <code>LICENSE</code>
+            <code>MusicBrainz/TRM Id</code>
           </td>
         </tr>
         <tr>
-          <th>Original Year <sup id="cite_ref-lastfmplugin_2-2" class="reference"><a href="#cite_note-lastfmplugin-2">[3]</a></sup>
+          <th> <a href="http://musicbrainz.org/doc/Disc_ID" title="Disc ID">MusicBrainz Disc Id</a>
           </th>
           <td>
-            <code>originalyear</code>
+            <code>musicbrainz_discid</code>
           </td>
           <td>
-            <code>TXXX:originalyear</code>
+            <code>TXXX:MusicBrainz Disc Id</code>
           </td>
           <td>
-            <code>ORIGINALYEAR</code>
+            <code>MUSICBRAINZ_DISCID</code>
           </td>
           <td>
-            <code>ORIGINALYEAR</code>
+            <code>MUSICBRAINZ_DISCID</code>
           </td>
           <td>
+            <code>----:com.apple.iTunes:MusicBrainz Disc Id</code>
           </td>
           <td>
+            <code>MusicBrainz/Disc Id</code>
           </td>
         </tr>
         <tr>
@@ -1565,6 +1543,48 @@
           </td>
         </tr>
         <tr>
+          <th> <a href="http://musicbrainz.org/doc/PUID" title="PUID">MusicIP PUID</a>
+          </th>
+          <td>
+            <code>musicip_puid</code>
+          </td>
+          <td>
+            <code>TXXX:MusicIP PUID</code>
+          </td>
+          <td>
+            <code>MUSICIP_PUID</code>
+          </td>
+          <td>
+            <code>MUSICIP_PUID</code>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:MusicIP PUID</code>
+          </td>
+          <td>
+            <code>MusicIP/PUID</code>
+          </td>
+        </tr>
+        <tr>
+          <th>MusicIP Fingerprint
+          </th>
+          <td>
+            <code>musicip_fingerprint</code>
+          </td>
+          <td>
+            <code>TXXX:MusicMagic Fingerprint</code>
+          </td>
+          <td>
+            <code>FINGERPRINT=MusicMagic Fingerprint</code> <i>{fingerprint}</i>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>----:com.apple.iTunes:fingerprint</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
           <th>Website (official artist website)
           </th>
           <td>
@@ -1578,26 +1598,6 @@
           </td>
           <td>
             <code>Weblink</code>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <th>Work Title (Picard&gt;=1.3)
-          </th>
-          <td>
-            <code>work</code>
-          </td>
-          <td>
-            <code>TOAL</code>
-          </td>
-          <td>
-            <code>WORK</code>
-          </td>
-          <td>
-            <code>WORK</code>
           </td>
           <td>
           </td>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -267,13 +267,13 @@
           </td>
         </tr>
         <tr>
-          <th>Original Release Year <sup id="cite_ref-lastfmplugin_2-2" class="reference"><a href="#cite_note-lastfmplugin-2">[3]</a></sup>
+          <th>Original Release Year <sup id="cite_ref-0" class="reference"><a href="#cite_note-0">[1]</a></sup>
           </th>
           <td>
             <code>originalyear</code>
           </td>
           <td>
-            <code>TXXX:originalyear</code>
+            <code></code>
           </td>
           <td>
             <code>ORIGINALYEAR</code>


### PR DESCRIPTION
This replaces PR #21. The tag mappings described here are part of Picard 1.3.1 and not 1.4 (as I originally anticipated).