### PR TITLE
Improve the Linux download links

### DIFF
--- a/website/frontend/templates/docs/linux.html
+++ b/website/frontend/templates/docs/linux.html
@@ -11,41 +11,6 @@
         <a href="/downloads/#source" title="Source code for MusicBrainz Picard">here</a>.
       </p>
 
-      <h1 id="arch_linux">Arch Linux</h1>
-      <span>
-        <p>Arch Linux has the picard package in the community repositor, simply run: </p>
-        <pre>sudo pacman -S picard</pre>
-        <p>
-          <a rel="nofollow" class="external text" href="http://wiki.archlinux.org/index.php/Pacman#Repositories">wiki.archlinux</a>
-          tells you how to enable the community repository, if you haven't done this already.
-        </p>
-      </span>
-
-      <h1 id="debian">Debian</h1>
-      <span>
-        <p>
-          Picard 0.11-2.1 is available in the Debian Repositories for
-          <a rel="nofollow" class="external text" href="http://packages.debian.org/stable/picard">Stable (Squeeze)</a>.
-          <b>Note:</b> versions prior to 0.15 do not support
-          <a href="https://musicbrainz.org/doc/Server_Release_Notes/20110516" title="Server Release Notes/20110516">NGS</a>.
-        </p>
-        <p>
-          Picard 1.0-1 is available in the Debian Repositories for
-          <a rel="nofollow" class="external text" href="http://packages.debian.org/wheezy/picard">Testing (Wheezy)</a>.
-          It may be possible to run a more up-to-date version of Picard on Debian Stable using apt-pinning.
-        </p>
-        <p>
-          There is also a .deb of Version 0.12.1-1 for Debian Lenny build by kaiserbert available for download
-          <a rel="nofollow" class="external text" href="http://users.musicbrainz.org/~outsidecontext/picard/picard_0.12.1-1_i386.deb">here</a>.
-          To install the .deb just download and type <i>sudo dpkg -i picard_0.12.1-1_i386.deb</i>.
-        </p>
-        <p>
-          You can find a
-          <a rel="nofollow" class="external text" href="http://forums.musicbrainz.org/viewtopic.php?pid=10501#p10501">thread</a>
-          about the .deb for Lenny in the forum.
-        </p>
-      </span>
-
       <h1 id="fedora">Fedora 7, 8 and Higher</h1>
       <span>
         <p>Picard is now in the official Fedora package collection: </p>
@@ -69,16 +34,6 @@
         </p>
       </span>
 
-      <h1 id="gentoo">Gentoo</h1>
-      <span>
-        <p>Picard Qt is now included in Gentoo Portage. To install Picard, simply run:</p>
-        <pre>emerge --sync emerge picard </pre>
-        <p>
-          Note that you should enable the USE flag "ffmpeg" if you want acoustinc fingerprinting, and "cdaudio"
-          if you want to recognize CDs from your drive.
-        </p>
-      </span>
-
       <h1 id="mandriva">Mandriva</h1>
       <span>
         <p>
@@ -89,67 +44,11 @@
         <p>or by selecting it in rpmdrake. </p>
       </span>
 
-      <h1 id="suse_opensuse">SUSE / OpenSUSE</h1>
-      <span>
-        <p>
-          RPM builds for various SUSE versions can be found as well as 1-click installed in the OpenSUSE
-          Software directory.
-        </p>
-
-        <p>Select the correct one for your OpenSUSE version. </p>
-        <p>
-          <a rel="nofollow" class="external free" href="http://software.opensuse.org/search?p=1&amp;q=picard">
-            http://software.opensuse.org/search?p=1&amp;q=picard
-          </a>
-        </p>
-
-        <p>
-          This version does not automatically install optional things like PUID support. If you want to ensure
-          you've got full functionality, also make sure RPMs for the following are installed:
-        </p>
-        <p>libdiscid0 python-mutagen python-qt4 libofa ffmpeg </p>
-        <p>libdiscid0 is available from the same repository as Picard linked above. </p>
-
-        <p>
-          The other RPMs are available from SUSE default main repository, as well as Packman's repository
-          (<a rel="nofollow" class="external free" href="http://packman.links2linux.org">http://packman.links2linux.org</a>).
-          Just make sure you have Packman's repo set up and search for those 5 RPMs to ensure they are
-          installed.
-        </p>
-      </span>
-
-      <h1 id="ubuntu">Ubuntu</h1>
-      <span>
-        <p>
-          Available in
-          <a rel="nofollow" class="external text" href="http://packages.ubuntu.com/search?keywords=picard&amp;searchon=names&amp;exact=1&amp;suite=all&amp;section=all">Ubuntu's universe repository</a>
-          since Feisty. To install it run this command or use
-          <a rel="nofollow" class="external text" href="https://help.ubuntu.com/community/SynapticHowto">Synaptic</a> instead.
-          <pre>sudo apt-get install picard</pre>
-        </p>
-
-        <p>
-          Latest official packages also available via the main
-          <a rel="nofollow" class="external text" href="https://launchpad.net/picard">Launchpad</a> page.
-        </p>
-
-        <p>
-          Daily builds available at
-          <a rel="nofollow" class="external text" href="https://launchpad.net/~musicbrainz-developers">here</a>.
-        </p>
-      </span>
-    </div>
-
     <div class="col-md-4">
       <div id="sidebar" class="hidden-xs">
         <ul class="nav" data-spy="affix" data-offset-top="200">
-          <li class="active"><a href="#arch_linux">Arch Linux</a></li>
-          <li><a href="#debian">Debian</a></li>
-          <li><a href="#fedora">Fedora</a></li>
-          <li><a href="#gentoo">Gentoo</a></li>
+          <li class="active"><a href="#fedora">Fedora</a></li>
           <li><a href="#mandriva">Mandriva</a></li>
-          <li><a href="#suse_opensuse">SUSE / OpenSUSE</a></li>
-          <li><a href="#ubuntu">Ubuntu</a></li>
         </ul>
         <!-- <a class="back-to-top" href="#top"> Back to top </a> -->
       </div>

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -170,6 +170,12 @@
                     </td>
                   </tr>
                   <tr>
+                    <td>Debian</td>
+                    <td>
+                      <a href="https://packages.debian.org/jessie/picard">Stable</a>
+                    </td>
+                  </tr>
+                  <tr>
                     <td>Fedora</td>
                     <td>
                       <a href="{{ url_for('docs.show_pages', page='faq', _anchor='fedora-acoustid') }}">{{ _("Read the FAQ") }}</a>
@@ -187,6 +193,12 @@
                     <td>Gentoo</td>
                     <td>
                       <a href="http://packages.gentoo.org/package/media-sound/picard">media-sound/picard</a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>OpenSUSE</td>
+                    <td>
+                      <a href="https://software.opensuse.org/package/picard?search_term=picard">13.2</a>
                     </td>
                   </tr>
                   <tr>

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -246,7 +246,7 @@
                     </td>
                   </tr>
                   <tr>
-                    <td>1.4 ({{ _("occasionally unstable") }})</td>
+                    <td>1.4 ({{ _("unstable") }})</td>
                     <td>-</td>
                     <td>~2.0 MB</td>
                     <td>

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -162,11 +162,11 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td>Ubuntu</td>
+                    <td>Arch Linux</td>
                     <td>
-                      <a href="https://launchpad.net/~musicbrainz-developers/+archive/stable">MusicBrainz Stable PPA</a>
+                      <a href="https://www.archlinux.org/packages/community/x86_64/picard/">Community</a>
                       &middot
-                      <a href="https://launchpad.net/~musicbrainz-developers/+archive/daily">MusicBrainz Daily PPA (Unstable)</a>
+                      <a href="https://aur.archlinux.org/packages/picard-git/">AUR</a>
                     </td>
                   </tr>
                   <tr>
@@ -182,14 +182,6 @@
                     </td>
                   </tr>
                   <tr>
-                    <td>Arch Linux</td>
-                    <td>
-                      <a href="https://www.archlinux.org/packages/community/x86_64/picard/">Community</a>
-                      &middot
-                      <a href="https://aur.archlinux.org/packages/picard-git/">AUR</a>
-                    </td>
-                  </tr>
-                  <tr>
                     <td>Gentoo</td>
                     <td>
                       <a href="http://packages.gentoo.org/package/media-sound/picard">media-sound/picard</a>
@@ -199,6 +191,14 @@
                     <td>OpenSUSE</td>
                     <td>
                       <a href="https://software.opensuse.org/package/picard?search_term=picard">13.2</a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Ubuntu</td>
+                    <td>
+                      <a href="https://launchpad.net/~musicbrainz-developers/+archive/stable">MusicBrainz Stable PPA</a>
+                      &middot
+                      <a href="https://launchpad.net/~musicbrainz-developers/+archive/daily">MusicBrainz Daily PPA (Unstable)</a>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
This pull request updates the download links for some distributions and cleans
up the page with per-distribution instructions by moving most of them into the
table on /downloads.

I'm not familiar with Fedora & Mandrive, so I didn't touch the instructions for
them.