### PR TITLE
Update IRC channel name

### DIFF
--- a/website/frontend/templates/docs/development.html
+++ b/website/frontend/templates/docs/development.html
@@ -22,7 +22,7 @@
       <p>
         If you are interested in providing development assistance, contact us by either posting on the
         <a href="https://musicbrainz.org/doc/Developers_Mailing_List">developers mailing list</a> or joining the
-        <code>#musicbrainz-devel</code> IRC channel on <code>irc.freenode.net</code>.
+        <code>#metabrainz</code> IRC channel on <code>irc.freenode.net</code>.
       </p>
 
       <p>


### PR DESCRIPTION
I saw https://github.com/metabrainz/mbspotify/pull/27 and decided to check if there were any other places referring to the old channel.